### PR TITLE
add libwebp package for dynmap support

### DIFF
--- a/build/root/install.sh
+++ b/build/root/install.sh
@@ -39,7 +39,7 @@ mv /tmp/scripts-master/shell/arch/docker/*.sh /usr/local/bin/
 ####
 
 # define pacman packages
-pacman_packages="jre8-openjdk-headless jre11-openjdk-headless jre17-openjdk-headless jre-openjdk-headless gcc git"
+pacman_packages="jre8-openjdk-headless jre11-openjdk-headless jre17-openjdk-headless jre-openjdk-headless gcc git libwebp"
 
 # install compiled packages using pacman
 if [[ ! -z "${pacman_packages}" ]]; then


### PR DESCRIPTION
The [Dynmap](https://github.com/webbukkit/dynmap) plugin allows Minecraft server operators to host a web map of their server. By default, the map tiles are rendered as `jpg`s, but `webp` can also be used to save space.
Enabling this option requires the libwebp package to be installed.