### PR TITLE
Adding support to Java 21

### DIFF
--- a/build/root/install.sh
+++ b/build/root/install.sh
@@ -39,7 +39,7 @@ mv /tmp/scripts-master/shell/arch/docker/*.sh /usr/local/bin/
 ####
 
 # define pacman packages
-pacman_packages="jre8-openjdk-headless jre11-openjdk-headless jre17-openjdk-headless jre-openjdk-headless gcc git libwebp rust"
+pacman_packages="jre8-openjdk-headless jre11-openjdk-headless jre17-openjdk-headless jre21-openjdk-headless jre-openjdk-headless gcc git libwebp rust"
 
 # install compiled packages using pacman
 if [[ ! -z "${pacman_packages}" ]]; then
@@ -151,6 +151,9 @@ elif [[ "${JAVA_VERSION}" == "11" ]]; then
 elif [[ "${JAVA_VERSION}" == "17" ]]; then
 	ln -fs '/usr/lib/jvm/java-17-openjdk/bin/java' '/usr/bin/java'
 	archlinux-java set java-17-openjdk
+elif [[ "${JAVA_VERSION}" == "21" ]]; then
+	ln -fs '/usr/lib/jvm/java-21-openjdk/bin/java' '/usr/bin/java'
+	archlinux-java set java-21-openjdk
 elif [[ "${JAVA_VERSION}" == "latest" ]]; then
 	ln -fs "/usr/lib/jvm/java-${latest_java_version}-openjdk/bin/java" '/usr/bin/java'
 	archlinux-java set java-${latest_java_version}-openjdk


### PR DESCRIPTION
Currently, the supported versions of java are 8, 11, 17 and 23.

After running the command from `install.sh`: `pacman -Qi jre-openjdk-headless | grep -P -o -m 1 '^Version\s*: \K.+' | grep -P -o -m 1 '^[0-9]+'` the returned value is `23`

The recognized values to the JAVA_VERSION environment variable are only 8, 11,17 and latest, which means we're skipping the version 21.

This PR adds support to the JRE 21.
